### PR TITLE
adding RuntimeDirectory to Service delacartion to create socket directory

### DIFF
--- a/systemd/front_door_authorizer.service
+++ b/systemd/front_door_authorizer.service
@@ -10,7 +10,7 @@ After=front_door_latch.service
 Type=simple
 
 LogNamespace=keep
-
+RuntimeDirectory=queeriouslabs
 WorkingDirectory=/home/marcidy/100101SecBot
 
 Environment="QUEERIOUSLABS_ENV=PROD"

--- a/systemd/front_door_latch.service
+++ b/systemd/front_door_latch.service
@@ -8,7 +8,7 @@ Type=simple
 LogNamespace=keep
 
 WorkingDirectory=/home/marcidy/100101SecBot
-
+RuntimeDirectory=queeriouslabs
 Environment="QUEERIOUSLABS_ENV=PROD"
 ExecStart=/home/marcidy/venv/bin/python3 /home/marcidy/100101SecBot/relay.py
 Restart=always


### PR DESCRIPTION
The unix domain sockets are set to be in `/run/queeriouslabs/` but this directory did not persist over a reboot, as it needs to be managed by systemd.  

The fix is to add `RuntimeDirectory=queeriouslabs`  to the unit service declarations for the units which require that directory.  This is now done and the services restarted, directory is created, and RFID is functional again.